### PR TITLE
Upgrade glob dependency to remove vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "querybox",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A box for your queries",
   "main": "index.js",
   "scripts": {
@@ -20,12 +20,12 @@
   },
   "devDependencies": {
     "async": "^2.6.0",
-    "mocha": "~1.17.1",
+    "mocha": "^5.2.0",
+    "okay": "^0.3.0",
     "pg-query": "^0.11.0",
-    "pg.js": "*",
-    "okay": "^0.3.0"
+    "pg.js": "*"
   },
   "dependencies": {
-    "glob": "~3.2.8"
+    "glob": "^7.1.3"
   }
 }


### PR DESCRIPTION
- Upgrade glob to 7.1.3 to remove vulnerability with minimatch
- Bump version

Glob 3.2.8 depends on minimatch 0.3.0 which had a vulnerability: https://www.npmjs.com/advisories/118